### PR TITLE
Add JSON-formatted logging of all events to file.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 type Config struct {
@@ -17,6 +18,7 @@ type Config struct {
 	Metrics  ConfigMetrics
 	Alerts   map[string]ConfigAlert
 	Views    map[string]ConfigView
+	Eventlog ConfigEventlog
 }
 
 type ConfigMail struct {
@@ -46,6 +48,11 @@ type ConfigAlert struct {
 type ConfigView struct {
 	Regexp string
 	Alerts []string
+}
+
+type ConfigEventlog struct {
+	Path string
+	Mode os.FileMode
 }
 
 var log = logging.MustGetLogger("lovebeat")
@@ -93,6 +100,10 @@ func ReadConfig(fname string, dirname string) Config {
 			Server: "",
 			Prefix: "lovebeat",
 		},
+		Eventlog: ConfigEventlog{
+			Path: "",
+			Mode: 644, // Reinterpreted as octal below
+		},
 	}
 	readFile(&conf, fname)
 	if dirname != "" {
@@ -104,5 +115,7 @@ func ReadConfig(fname string, dirname string) Config {
 			}
 		}
 	}
+	mode, _ := strconv.ParseInt(strconv.FormatInt(int64(conf.Eventlog.Mode), 10), 8, 64)
+	conf.Eventlog.Mode = os.FileMode(mode)
 	return conf
 }

--- a/eventlog/eventlog.go
+++ b/eventlog/eventlog.go
@@ -1,0 +1,47 @@
+package eventlog
+
+import (
+	"encoding/json"
+	"github.com/boivie/lovebeat/eventbus"
+	"github.com/boivie/lovebeat/service"
+	"github.com/op/go-logging"
+	"io"
+	"reflect"
+	"time"
+)
+
+var log = logging.MustGetLogger("lovebeat")
+
+type EventLog struct {
+	writer io.Writer
+}
+
+func New(writer io.Writer) *EventLog {
+	return &EventLog{writer}
+}
+
+func (el *EventLog) Register(bus *eventbus.EventBus) {
+	bus.RegisterHandler(
+		el.eventHandler,
+		service.ServiceStateChangedEvent{},
+		service.ViewStateChangedEvent{})
+}
+
+func (el *EventLog) eventHandler(ev interface{}) {
+	t := camelToSnakeCase(reflect.TypeOf(ev).Name())
+	jev := map[string]interface{}{
+		"ts":   time.Now().UTC(),
+		"type": t,
+		t:      &ev,
+	}
+	buf, err := json.Marshal(jev)
+	if err != nil {
+		log.Error("Could not marshal event %+v: %s", jev, err)
+		return
+	}
+	_, err = el.writer.Write([]byte(string(buf) + "\n"))
+	if err != nil {
+		log.Error("Error writing event: %s", err)
+		return
+	}
+}

--- a/eventlog/snakecase.go
+++ b/eventlog/snakecase.go
@@ -1,0 +1,24 @@
+package eventlog
+
+import (
+	"unicode"
+)
+
+// camelToSnakeCase converts a string containing one or more camel
+// cased words into their snake cased equivalents. For example,
+// "CamelCase" results in "camel_case".
+func camelToSnakeCase(s string) string {
+	result := ""
+	boundary := true // Are we on a word boundary?
+	for _, r := range s {
+		if unicode.IsUpper(r) && !boundary {
+			result += "_" + string(unicode.ToLower(r))
+		} else if unicode.IsUpper(r) {
+			result += string(unicode.ToLower(r))
+		} else {
+			result += string(r)
+		}
+		boundary = !(unicode.IsLetter(r) || unicode.IsDigit(r))
+	}
+	return result
+}

--- a/eventlog/snakecase_test.go
+++ b/eventlog/snakecase_test.go
@@ -1,0 +1,28 @@
+package eventlog
+
+import (
+	"testing"
+)
+
+func TestCamelToSnakeCase(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"loweronly", "loweronly"},
+		{"LeadingCapCamelCase", "leading_cap_camel_case"},
+		{"javaStyleCamelCase", "java_style_camel_case"},
+		{"TrailingCapX", "trailing_cap_x"},
+		{"./$%()[]{}", "./$%()[]{}"},
+		{"ÄckligRäka", "äcklig_räka"},
+		{"_LeadingUnderscore", "_leading_underscore"},
+		{"MultiWord CamelCase String", "multi_word camel_case string"},
+		{"Test123Digits", "test123_digits"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := camelToSnakeCase(c.in)
+		if got != c.want {
+			t.Errorf("CamelToSnakeCase(%q) == %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/lovebeat.cfg
+++ b/lovebeat.cfg
@@ -45,3 +45,11 @@
 #[metrics]
 #server = ""
 #prefix = "lovebeat"
+
+##
+## Configuration of the logfile where events are logged. An empty
+## or unset path disables the logging.
+#
+#[eventlog]
+#path = "/var/log/lovebeat/events.json"
+#mode = 644

--- a/model/model.go
+++ b/model/model.go
@@ -17,19 +17,19 @@ const BeatHistoryCount = 100
 
 // Service is something that can issue a beat
 type Service struct {
-	Name           string  // Name of the service
-	LastBeat       int64   // Timestamp, in milliseconds since epoch, of last beat
-	BeatHistory    []int64 // The last X duration (in milliseconds) between heartbeats
-	WarningTimeout int64   // The warning timeout, in milliseconds
-	ErrorTimeout   int64   // The error timeout, in milliseconds
-	State          string  // One of the StateXX constants
+	Name           string  `json:"name"`            // Name of the service
+	LastBeat       int64   `json:"last_beat"`       // Timestamp, in milliseconds since epoch, of last beat
+	BeatHistory    []int64 `json:"beat_history"`    // The last X duration (in milliseconds) between heartbeats
+	WarningTimeout int64   `json:"warning_timeout"` // The warning timeout, in milliseconds
+	ErrorTimeout   int64   `json:"error_timeout"`   // The error timeout, in milliseconds
+	State          string  `json:"state"`           // One of the StateXX constants
 }
 
 // View is a collection of services
 type View struct {
-	Name        string // Name of the view
-	State       string // One of the StateXX constant
-	Regexp      string // Services matching this expression will be included in the view
-	IncidentNbr int    // Incrementing number everytime the view leaves the StateOk state
-	Alerts      []string
+	Name        string   `json:"name"`         // Name of the view
+	State       string   `json:"state"`        // One of the StateXX constant
+	Regexp      string   `json:"regexp"`       // Services matching this expression will be included in the view
+	IncidentNbr int      `json:"incident_nbr"` // Incrementing number everytime the view leaves the StateOk state
+	Alerts      []string `json:"alerts"`
 }

--- a/service/events.go
+++ b/service/events.go
@@ -5,13 +5,17 @@ import (
 )
 
 type ViewStateChangedEvent struct {
-	View     model.View
-	Previous string
-	Current  string
+	View     model.View `json:"view"`
+	Previous string     `json:"previous"`
+	Current  string     `json:"current"`
 }
 
 type ServiceStateChangedEvent struct {
-	Service  model.Service
-	Previous string
-	Current  string
+	Service  model.Service `json:"service"`
+	Previous string        `json:"previous"`
+	Current  string        `json:"current"`
 }
+
+// When adding a new expression struct type here, don't forget
+// to add it to the test cases so the member names are checked
+// for conformity.

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"testing"
+)
+
+var (
+	fieldNameRegexp = regexp.MustCompile("^[a-z0-9_]+$")
+)
+
+func TestEventMembersHaveCorrectJSONCase(t *testing.T) {
+	events := []interface{}{
+		ServiceStateChangedEvent{},
+		ViewStateChangedEvent{},
+	}
+
+	for i, e := range events {
+		// Serialize each event struct to JSON and back again
+		// into a map so that we can inspect the resulting
+		// names of the fields.
+		buf, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("Failed to marshal message %d to JSON: %+v: %s", i, e, err)
+		}
+		var m map[string]interface{}
+		err = json.Unmarshal(buf, &m)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal message %d to JSON: %q: %s", i, string(buf), err)
+		}
+		checkMapKeyNames(m, t)
+	}
+}
+
+func checkMapKeyNames(m map[string]interface{}, t *testing.T) {
+	for k := range m {
+		if !fieldNameRegexp.MatchString(k) {
+			t.Errorf("JSON field name %q doesn't match the required pattern %q",
+				k, fieldNameRegexp.String())
+		}
+		v := m[k]
+		if reflect.ValueOf(v).Kind() == reflect.Map {
+			checkMapKeyNames(v.(map[string]interface{}), t)
+		}
+	}
+}


### PR DESCRIPTION
This new optional feature serializes the structs of all events
that get submitted to the event bus as JSON and writes to a file.
This can e.g. be used to trigger alerts, submit events to a
message broker, or store them into a database of some sort.

Issue: #2