### PR TITLE
slack alerter

### DIFF
--- a/alert/alert.go
+++ b/alert/alert.go
@@ -34,6 +34,7 @@ func ViewStateChanged(ev service.ViewStateChangedEvent) {
 func RegisterAlerters(bus *eventbus.EventBus, cfg config.Config) {
 	alerters = []Alerter{
 		NewMailAlerter(cfg),
+		NewSlackhookAlerter(cfg),
 		NewWebhooksAlerter(cfg),
 	}
 	alerts = cfg.Alerts

--- a/alert/slack.go
+++ b/alert/slack.go
@@ -1,0 +1,101 @@
+package alert
+
+import (
+	"bytes"
+	"net/http"
+	"io/ioutil"
+	"github.com/boivie/lovebeat/config"
+	"github.com/boivie/lovebeat/service"
+	"github.com/franela/goreq"
+	"text/template"
+	"time"
+	"net/url"
+)
+
+type slackhook struct {
+	Uri  string
+	Data service.ViewStateChangedEvent
+}
+
+type slackhookAlerter struct {
+	cmds chan slackhook
+}
+
+func (m slackhookAlerter) Notify(cfg config.ConfigAlert, ev service.ViewStateChangedEvent) {
+
+	if cfg.Slackhook != "" {
+
+		m.cmds <- slackhook{Uri: cfg.Slackhook, Data: ev }
+	}
+
+}
+
+func (m slackhookAlerter) Worker(q chan slackhook, cfg *config.ConfigSlackhook) {
+	for {
+
+		select {
+		case slackhook := <-q:
+
+			var err error
+
+			var context = make(map[string]interface{})
+			context["View"] = slackhook.Data.View
+			context["Previous"] = slackhook.Data.Previous
+			context["Current"] = slackhook.Data.Current
+
+			tmpl := cfg.Template
+
+			t, err := template.New("template").Parse(tmpl)
+			if err != nil {
+				log.Error("error trying to parse slackhook template:%s:err:%v:", tmpl, err)
+				return
+			}
+			var doc bytes.Buffer
+
+			err = t.Execute(&doc, context)
+			if err != nil {
+				log.Error("Failed to render template", err)
+				return
+			}
+
+			req := goreq.Request{
+			    Method: "POST",
+				Uri:         cfg.Uri,
+				Accept:      "*/*",
+				ContentType: "application/x-www-form-urlencoded",
+				UserAgent:   "Lovebeat",
+				Timeout:     10 * time.Second,
+				Body:        "payload=" + url.QueryEscape(doc.String()),
+			}
+
+			req.AddHeader("X-Lovebeat", "1")
+
+			res, err := req.Do()
+			if err != nil {
+				log.Error("Failed to post slackhook:%v:", err)
+			}
+
+			robots, err := ioutil.ReadAll(res.Body)
+			res.Body.Close()
+
+			//it returned a 200 so ignore any error here
+			if err != nil {
+				log.Error("OK:unreadable response:%v:", err)
+			} else if res.StatusCode != http.StatusOK {
+				log.Error("NOK:non-200:%d:", res.StatusCode)
+			} else {
+				log.Info("OK:response:%s:", string(robots))
+			}
+
+		}
+	}
+
+}
+
+func NewSlackhookAlerter(cfg config.Config) Alerter {
+	goreq.SetConnectTimeout(5 * time.Second)
+	var q = make(chan slackhook, 100)
+	var w = slackhookAlerter{cmds: q}
+	go w.Worker(q, &cfg.Slackhook)
+	return &w
+}

--- a/alert/slack.go
+++ b/alert/slack.go
@@ -2,14 +2,14 @@ package alert
 
 import (
 	"bytes"
-	"net/http"
-	"io/ioutil"
 	"github.com/boivie/lovebeat/config"
 	"github.com/boivie/lovebeat/service"
 	"github.com/franela/goreq"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"text/template"
 	"time"
-	"net/url"
 )
 
 type slackhook struct {
@@ -25,7 +25,7 @@ func (m slackhookAlerter) Notify(cfg config.ConfigAlert, ev service.ViewStateCha
 
 	if cfg.Slackhook != "" {
 
-		m.cmds <- slackhook{Uri: cfg.Slackhook, Data: ev }
+		m.cmds <- slackhook{Uri: cfg.Slackhook, Data: ev}
 	}
 
 }
@@ -59,7 +59,7 @@ func (m slackhookAlerter) Worker(q chan slackhook, cfg *config.ConfigSlackhook) 
 			}
 
 			req := goreq.Request{
-			    Method: "POST",
+				Method:      "POST",
 				Uri:         cfg.Uri,
 				Accept:      "*/*",
 				ContentType: "application/x-www-form-urlencoded",

--- a/alert/slack.go
+++ b/alert/slack.go
@@ -71,6 +71,7 @@ func (m slackhookAlerter) Worker(q chan slackhook, cfg *config.ConfigSlackhook) 
 			req.AddHeader("X-Lovebeat", "1")
 
 			res, err := req.Do()
+
 			if err != nil {
 				log.Error("Failed to post slackhook:%v:", err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	Mail     ConfigMail
+	Slackhook     ConfigSlackhook
 	Udp      ConfigBind
 	Tcp      ConfigBind
 	Http     ConfigBind
@@ -22,6 +23,11 @@ type Config struct {
 type ConfigMail struct {
 	From   string
 	Server string
+}
+
+type ConfigSlackhook struct {
+	Uri   string
+	Template string
 }
 
 type ConfigBind struct {
@@ -41,6 +47,7 @@ type ConfigMetrics struct {
 type ConfigAlert struct {
 	Mail    string
 	Webhook string
+	Slackhook string
 }
 
 type ConfigView struct {
@@ -75,6 +82,10 @@ func ReadConfig(fname string, dirname string) Config {
 		Mail: ConfigMail{
 			From:   "lovebeat@example.com",
 			Server: "localhost:25",
+		},
+		Slackhook: ConfigSlackhook{
+			Uri:   "http://localhost:1323/services/deded/wswswsw/erferferferferf",
+			Template: `{"channel": "#alert-test", "username": "webhookbot", "text": "slack check {{.View.Name}}-{{.View.IncidentNbr}}", "icon_emoji": ":ghost:"}`,
 		},
 		Udp: ConfigBind{
 			Listen: ":8127",

--- a/lovebeat.cfg
+++ b/lovebeat.cfg
@@ -11,6 +11,16 @@
 #filename = "lovebeat.db"
 #interval = 60
 
+[views]
+
+	[views.slack]
+	regexp = ".*"
+	alerts = ["slack1"]
+
+[alerts]
+
+	[alerts.slack1]
+	posthook = "nexus"
 
 ##
 ## UDP listener, in statsd format
@@ -36,6 +46,10 @@
 #[mail]
 #server = "localhost:25"
 #from = "lovebeat@example.com"
+
+#[posthook]
+#uri = "https://hooks.slack.com/services/aaa/sss/ddd"
+#template = "{"channel": "#alert-test", "username": "webhookbot", "text": "slack check {{.View.Name}}-{{.View.IncidentNbr}}", "icon_emoji": ":ghost:"}"
 
 ##
 ## Metrics reporting to a statsd proxy, using the UDP protocol.

--- a/lovebeat.cfg
+++ b/lovebeat.cfg
@@ -20,7 +20,7 @@
 [alerts]
 
 	[alerts.slack1]
-	posthook = "nexus"
+	slackhook = "nexus"
 
 ##
 ## UDP listener, in statsd format


### PR DESCRIPTION
This sends alerts to slack, using a text/template in the config file to specify the content of the alert.  The default alert has alert text from the mail alert using the event context.

I think it would be better to integrate this with the webhook alerter, but I'd have to remove the webhook struct and anyway, I didn't figure out a generic way to get this going via the template.  If I can get the entire post content to come from the template this would be generic, but I had to do append the template text appended to "payload=".  Maybe you have an idea for how to get that into a single template, and then this would be a decent general webhook, with the post body entirely determined by the template.

Also I was guessing quite a bit to figure out how the config file should look.