### PR TITLE
Failing services names are added to the ViewStateChangedEvent so that…

### DIFF
--- a/alert/slack.go
+++ b/alert/slack.go
@@ -71,7 +71,7 @@ func (m slackAlerter) Worker(q <- chan slackAlert, cfg *config.ConfigSlack) {
 						SlackField{Title: "View Name", Value: view.Name, Short: true },
 						SlackField{Title: "Incident Number", Value: fmt.Sprintf("#%d", view.IncidentNbr), Short: true },
 						SlackField{Title: "From State", Value: prevUpper, Short: true },
-						SlackField{Title: "Failed Service(s)", Value: strings.Join(slackAlert.Data.FailedServices[:],","), Short: true },
+						SlackField{Title: "Failed Service(s)", Value: strings.Join(formatFailedServices(slackAlert.Data)[:],","), Short: true },
 						SlackField{Title: "To State", Value: currentUpper, Short: true },
 					},
 				},
@@ -94,6 +94,14 @@ func (m slackAlerter) Worker(q <- chan slackAlert, cfg *config.ConfigSlack) {
 			log.Error("Failed to post slack alert: %v", err)
 		}
 	}
+}
+
+func formatFailedServices(event service.ViewStateChangedEvent) []string {
+	var services = make([]string, 0)
+	for _, service := range event.FailedServices {
+		services = append(services, fmt.Sprintf("%s (%s)", service.Name, service.State))
+	}
+	return services
 }
 
 func NewSlackAlerter(cfg config.Config) Alerter {

--- a/alert/slack.go
+++ b/alert/slack.go
@@ -71,6 +71,7 @@ func (m slackAlerter) Worker(q <- chan slackAlert, cfg *config.ConfigSlack) {
 						SlackField{Title: "View Name", Value: view.Name, Short: true },
 						SlackField{Title: "Incident Number", Value: fmt.Sprintf("#%d", view.IncidentNbr), Short: true },
 						SlackField{Title: "From State", Value: prevUpper, Short: true },
+						SlackField{Title: "Failed Service(s)", Value: strings.Join(slackAlert.Data.FailedServices[:],","), Short: true },
 						SlackField{Title: "To State", Value: currentUpper, Short: true },
 					},
 				},

--- a/service/events.go
+++ b/service/events.go
@@ -6,11 +6,10 @@ import (
 
 // ViewStateChangedEvent will be sent when a view has changed state
 type ViewStateChangedEvent struct {
-	View           model.View `json:"view"`
-	Previous       string     `json:"previous"`
-	Current        string     `json:"current"`
-	FailedServices []string   `json:"failed"`
-
+	View           model.View        `json:"view"`
+	Previous       string            `json:"previous"`
+	Current        string            `json:"current"`
+	FailedServices []model.Service   `json:"failed"`
 }
 
 // ServiceStateChangedEvent will be sent when a service has changed state

--- a/service/events.go
+++ b/service/events.go
@@ -6,9 +6,11 @@ import (
 
 // ViewStateChangedEvent will be sent when a view has changed state
 type ViewStateChangedEvent struct {
-	View     model.View `json:"view"`
-	Previous string     `json:"previous"`
-	Current  string     `json:"current"`
+	View           model.View `json:"view"`
+	Previous       string     `json:"previous"`
+	Current        string     `json:"current"`
+	FailedServices []string   `json:"failed"`
+
 }
 
 // ServiceStateChangedEvent will be sent when a service has changed state

--- a/service/services.go
+++ b/service/services.go
@@ -71,7 +71,7 @@ func (svcs *Services) updateView(view View, ts int64) {
 			view.name(), view.data.IncidentNbr, ref.data.State,
 			view.data.State)
 
-		svcs.bus.Publish(ViewStateChangedEvent{view.data, ref.data.State, view.data.State})
+		svcs.bus.Publish(ViewStateChangedEvent{view.data, ref.data.State, view.data.State, view.failingServices()})
 	}
 }
 

--- a/service/view.go
+++ b/service/view.go
@@ -39,12 +39,12 @@ func (v *View) save(be backend.Backend, ref *View, ts int64) {
 	be.SaveView(&v.data)
 }
 
-func(v *View) failingServices() []string {
-	var failedServices = make([]string, 0)
+func(v *View) failingServices() []model.Service {
+	var failedServices = make([]model.Service, 0)
 	for _, s := range v.services {
 		if v.contains(s.name()) {
 			if (s.data.State == model.StateError || s.data.State == model.StateWarning) {
-				failedServices = append(failedServices, s.name() + " (" + s.data.State + ")")
+				failedServices = append(failedServices, s.data)
 			}
 		}
 	}

--- a/service/view.go
+++ b/service/view.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 )
 
+
 type View struct {
 	services map[string]*Service
 	data     model.View
@@ -36,4 +37,16 @@ func (v *View) save(be backend.Backend, ref *View, ts int64) {
 		v.data.IncidentNbr += 1
 	}
 	be.SaveView(&v.data)
+}
+
+func(v *View) failingServices() []string {
+	var failedServices = make([]string, 0)
+	for _, s := range v.services {
+		if v.contains(s.name()) {
+			if (s.data.State == model.StateError || s.data.State == model.StateWarning) {
+				failedServices = append(failedServices, s.name() + " (" + s.data.State + ")")
+			}
+		}
+	}
+	return failedServices
 }


### PR DESCRIPTION
… can be included in message.

Slack is updated to use failing services names.
